### PR TITLE
Merge check hook

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,8 +10,19 @@
         <url>http://ngs.ru/</url>
     </organization>
     <name>External Hooks</name>
-    <description>This plugin provides Post and Pre receive hooks using any external executable</description>
+    <description>This plugin provides Merge Check, Post and Pre receive hooks using any external executable</description>
     <packaging>atlassian-plugin</packaging>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.atlassian.bitbucket.server</groupId>
+                <artifactId>bitbucket-parent</artifactId>
+                <version>${bitbucket.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>com.atlassian.bitbucket.server</groupId>
@@ -33,7 +44,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.12</version>
+            <version>${slf4j.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -54,8 +65,8 @@
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
             <plugin>
@@ -77,8 +88,12 @@
         </plugins>
     </build>
     <properties>
-        <bitbucket.version>4.0.0-rc12</bitbucket.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <bitbucket.version>4.3.2</bitbucket.version>
         <bitbucket.data.version>${bitbucket.version}</bitbucket.data.version>
-        <amps.version>6.1.0</amps.version>
+        <atlassian-sal-api.version>3.0.5</atlassian-sal-api.version>
+        <slf4j.version>1.7.12</slf4j.version>
+        <amps.version>6.2.3</amps.version>
+        <plugin.testrunner.version>1.1.4</plugin.testrunner.version>
     </properties>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,11 @@
             <version>2.6</version>
             <scope>provided</scope>
         </dependency>
+        <!--<dependency>-->
+        <!--    <groupId>com.google.guava</groupId>-->
+        <!--    <artifactId>guava</artifactId>-->
+        <!--    <scope>provided</scope>-->
+        <!--</dependency>-->
     </dependencies>
     <build>
         <plugins>

--- a/src/main/java/com/ngs/stash/externalhooks/hook/ExternalMergeCheckHook.java
+++ b/src/main/java/com/ngs/stash/externalhooks/hook/ExternalMergeCheckHook.java
@@ -22,6 +22,14 @@ import java.util.Set;
 import java.nio.file.Files;
 
 import com.atlassian.bitbucket.pull.*;
+// import com.google.common.base.Predicate;
+// import static com.google.common.base.Charsets.UTF_8;
+// import static com.google.common.base.Joiner.on;
+// import static com.google.common.base.Throwables.propagate;
+// import static com.google.common.collect.Iterables.filter;
+// import static com.google.common.collect.Iterables.transform;
+// import static com.google.common.collect.Lists.newArrayList;
+// import static com.google.common.collect.Ordering.usingToString;
 import static com.ngs.stash.externalhooks.hook.ExternalMergeCheckHook.REPO_PROTOCOL.http;
 import static com.ngs.stash.externalhooks.hook.ExternalMergeCheckHook.REPO_PROTOCOL.ssh;
 
@@ -129,6 +137,7 @@ public class ExternalMergeCheckHook
         env.put("PULL_REQUEST_FROM_REPO_SLUG", pr.getFromRef().getRepository().getSlug() + "");
         env.put("PULL_REQUEST_FROM_SSH_CLONE_URL", cloneUrlFromRepository(ssh, pr.getFromRef().getRepository(), repoService));
         env.put("PULL_REQUEST_FROM_HTTP_CLONE_URL", cloneUrlFromRepository(http, pr.getFromRef().getRepository(), repoService));
+        // env.put("PULL_REQUEST_ACTION", prnfbPullRequestAction.getName());
         env.put("PULL_REQUEST_URL", getPullRequestUrl(properties, pr));
         env.put("PULL_REQUEST_ID", pr.getId() + "");
         env.put("PULL_REQUEST_VERSION", pr.getVersion() + "");
@@ -147,7 +156,19 @@ public class ExternalMergeCheckHook
         env.put("PULL_REQUEST_TO_REPO_SLUG", pr.getToRef().getRepository().getSlug() + "");
         env.put("PULL_REQUEST_TO_SSH_CLONE_URL", cloneUrlFromRepository(ssh, pr.getToRef().getRepository(), repoService));
         env.put("PULL_REQUEST_TO_HTTP_CLONE_URL", cloneUrlFromRepository(http, pr.getToRef().getRepository(), repoService));
+        // env.put("PULL_REQUEST_COMMENT_TEXT", getOrEmpty(variables, PULL_REQUEST_COMMENT_TEXT));
+        // env.put("PULL_REQUEST_MERGE_COMMIT", getOrEmpty(variables, PULL_REQUEST_MERGE_COMMIT));
+        // env.put("PULL_REQUEST_USER_DISPLAY_NAME", applicationUser.getDisplayName());
+        // env.put("PULL_REQUEST_USER_EMAIL_ADDRESS", applicationUser.getEmailAddress());
+        // env.put("PULL_REQUEST_USER_ID", applicationUser.getId() + "");
+        // env.put("PULL_REQUEST_USER_NAME", applicationUser.getName());
+        // env.put("PULL_REQUEST_USER_SLUG", applicationUser.getSlug());
         env.put("PULL_REQUEST_TITLE", pr.getTitle());
+        // env.put("PULL_REQUEST_REVIEWERS", iterableToString(transform(pr.getReviewers(), (p) -> p.getUser().getDisplayName())));
+        // env.put("PULL_REQUEST_REVIEWERS_ID", iterableToString(transform(pr.getReviewers(), (p) -> Integer.toString(p.getUser().getId()))));
+        // env.put("PULL_REQUEST_REVIEWERS_SLUG", iterableToString(transform(pr.getReviewers(), (p) -> p.getUser().getSlug())));
+        // env.put("PULL_REQUEST_REVIEWERS_APPROVED_COUNT", Integer.toString(newArrayList(filter(pr.getReviewers(), isApproved)).size()));
+        // env.put("PULL_REQUEST_PARTICIPANTS_APPROVED_COUNT", Integer.toString(newArrayList(filter(pr.getParticipants(), isApproved)).size()));
 
         String summaryMsg = "Merge request failed";
 
@@ -277,6 +298,18 @@ public class ExternalMergeCheckHook
     public enum REPO_PROTOCOL {
         ssh, http
     }
+
+    // private static final Predicate<PullRequestParticipant> isApproved = new Predicate<PullRequestParticipant>() {
+    //         @Override
+    //         public boolean apply(PullRequestParticipant input) {
+    //             return input.isApproved();
+    //         }
+    //     };
+
+    // private static String iterableToString(Iterable<String> slist) {
+    //     List<String> sorted = usingToString().sortedCopy(slist);
+    //     return on(',').join(sorted);
+    // }
 
     private static String cloneUrlFromRepository(
         REPO_PROTOCOL protocol,

--- a/src/main/java/com/ngs/stash/externalhooks/hook/ExternalPreReceiveHook.java
+++ b/src/main/java/com/ngs/stash/externalhooks/hook/ExternalPreReceiveHook.java
@@ -56,7 +56,7 @@ public class ExternalPreReceiveHook
     ) {
         Repository repo = context.getRepository();
 
-        // compat with  < 3.2.0
+        // compat with < 3.2.0
         String repoPath = this.properties.getRepositoryDir(repo).getAbsolutePath();
 
         Settings settings = context.getSettings();
@@ -179,7 +179,7 @@ public class ExternalPreReceiveHook
             if (!permissions.hasGlobalPermission(
                     authCtx.getCurrentUser(), Permission.SYS_ADMIN)) {
                 errors.addFieldError("exe",
-                    "You should be  Administrator to edit this field " +
+                    "You should be an Administrator to edit this field " +
                     "without \"safe mode\" option.");
                 return;
             }

--- a/src/main/java/com/ngs/stash/externalhooks/hook/helpers/ExternalHookResponse.java
+++ b/src/main/java/com/ngs/stash/externalhooks/hook/helpers/ExternalHookResponse.java
@@ -1,0 +1,28 @@
+package com.ngs.stash.externalhooks.hook.helpers;
+
+import java.io.PrintWriter;
+import com.atlassian.bitbucket.hook.HookResponse;
+
+import javax.annotation.Nonnull;
+
+public class ExternalHookResponse implements HookResponse {
+    PrintWriter outWriter;
+    PrintWriter errWriter;
+
+    public ExternalHookResponse(PrintWriter outWriter, PrintWriter errWriter) {
+        this.outWriter = outWriter;
+        this.errWriter = errWriter;
+    }
+
+    @Nonnull
+    @Override
+    public PrintWriter out() {
+        return outWriter;
+    }
+
+    @Nonnull
+    @Override
+    public PrintWriter err() {
+        return errWriter;
+    }
+}

--- a/src/main/java/com/ngs/stash/externalhooks/hook/helpers/ExternalRefChange.java
+++ b/src/main/java/com/ngs/stash/externalhooks/hook/helpers/ExternalRefChange.java
@@ -1,0 +1,52 @@
+package com.ngs.stash.externalhooks.hook.helpers;
+
+import com.atlassian.bitbucket.repository.RefChange;
+import com.atlassian.bitbucket.repository.RefChangeType;
+import com.atlassian.bitbucket.repository.MinimalRef;
+
+import javax.annotation.Nonnull;
+
+public class ExternalRefChange implements RefChange {
+    MinimalRef ref;
+    String refId;
+    String fromHash;
+    String toHash;
+    RefChangeType type;
+
+    public ExternalRefChange(String refId, String fromHash, String toHash, RefChangeType type) {
+        this.refId = refId;
+        this.fromHash = fromHash;
+        this.toHash = toHash;
+        this.type = type;
+    }
+
+    @Nonnull
+    @Override
+    public String getRefId() {
+        return refId;
+    }
+
+    @Nonnull
+    @Override
+    public MinimalRef getRef() {
+        return ref;
+    }
+
+    @Nonnull
+    @Override
+    public String getFromHash() {
+        return fromHash;
+    }
+
+    @Nonnull
+    @Override
+    public String getToHash() {
+        return toHash;
+    }
+
+    @Nonnull
+    @Override
+    public RefChangeType getType() {
+        return type;
+    }
+}

--- a/src/main/resources/atlassian-plugin.xml
+++ b/src/main/resources/atlassian-plugin.xml
@@ -38,4 +38,12 @@
       <directory location="/static/"/>
     </config-form>
   </repository-hook>
+  <repository-hook name="External Merge Check Hook" i18n-name-key="external-merge-check-hook.name" key="external-merge-check-hook" class="com.ngs.stash.externalhooks.hook.ExternalMergeCheckHook">
+    <description key="external-merge-check-hook.description">The External Merge Check Hook Plugin</description>
+    <icon>icon-example.png</icon>
+    <config-form name="External Merge Check Hook Config" key="external-merge-check-hook-config">
+      <view>com.ngs.stash.externalhooks.hook.externalprereceivehook.view</view>
+      <directory location="/static/"/>
+    </config-form>
+  </repository-hook>
 </atlassian-plugin>

--- a/src/main/resources/external-hooks.properties
+++ b/src/main/resources/external-hooks.properties
@@ -5,3 +5,6 @@ external-pre-receive-hook.description=The External Pre Receive Hook Plugin
 
 external-post-receive-hook.name=External Post Receive Hook
 external-post-receive-hook.description=The External Post Receive Hook Plugin
+
+external-merge-check-hook.name=External Merge Check Hook
+external-merge-check-hook.description=The External Merge Check Hook Plugin


### PR DESCRIPTION
an alternative to #32 , fixing #18 which reuses code from the pre-receive hook, and is built for Bitbucket server

**NOTE** the "remove duplicate code" commit is NOT tested. It compiles, but I don't have the means to test the functionality at the moment.