### PR TITLE
Adding compatibility with Bitbucket Server 5.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,11 +94,11 @@
     </build>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <bitbucket.version>4.4.0</bitbucket.version>
+        <bitbucket.version>5.0.1</bitbucket.version>
         <bitbucket.data.version>${bitbucket.version}</bitbucket.data.version>
         <atlassian-sal-api.version>3.0.5</atlassian-sal-api.version>
         <slf4j.version>1.7.12</slf4j.version>
-        <amps.version>6.2.3</amps.version>
+        <amps.version>6.2.9</amps.version>
         <plugin.testrunner.version>1.1.4</plugin.testrunner.version>
     </properties>
 </project>

--- a/src/main/java/com/ngs/stash/externalhooks/hook/ExternalPreReceiveHook.java
+++ b/src/main/java/com/ngs/stash/externalhooks/hook/ExternalPreReceiveHook.java
@@ -159,7 +159,7 @@ public class ExternalPreReceiveHook
                          (
                           refChange.getFromHash() + " " +
                           refChange.getToHash() + " " +
-                          refChange.getRefId() + "\n"
+                          refChange.getRef().getId() + "\n"
                           ).getBytes("UTF-8")
                          );
         }

--- a/src/main/java/com/ngs/stash/externalhooks/hook/helpers/ExternalRefChange.java
+++ b/src/main/java/com/ngs/stash/externalhooks/hook/helpers/ExternalRefChange.java
@@ -21,7 +21,6 @@ public class ExternalRefChange implements RefChange {
     }
 
     @Nonnull
-    @Override
     public String getRefId() {
         return refId;
     }


### PR DESCRIPTION
This adds compatibility with Bitbucket Server 5.0.1 addressing issue https://github.com/ngsru/atlassian-external-hooks/issues/51.